### PR TITLE
Include upper dependency version limit

### DIFF
--- a/src/EpiserverTemplate/EpiserverTemplate.csproj
+++ b/src/EpiserverTemplate/EpiserverTemplate.csproj
@@ -53,6 +53,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EPiServer.Framework" Version="11.1.0" />
+    <PackageReference Include="EPiServer.Framework" Version="[11.1.0, 12.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As per Episerver recommended best practice specify the next major breaking-change release version as the upper limit. Forces developers to test packages and release a new version with verified compatibility of the new version.